### PR TITLE
Add Register and Forgot Password on Login

### DIFF
--- a/lib/view/login_screen.dart
+++ b/lib/view/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../data/services/tmdb_api_service.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -12,6 +13,8 @@ class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController usernameController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
   final TmdbAuthService authService = TmdbAuthService();
+  static final Uri _registerUrl = Uri.parse('https://www.themoviedb.org/signup');
+  static final Uri _passwordResetUrl = Uri.parse('https://www.themoviedb.org/reset-password');
 
   void login() async {
     final requestToken = await authService.fetchRequestToken();
@@ -41,6 +44,14 @@ class _LoginScreenState extends State<LoginScreen> {
             TextField(controller: usernameController, decoration: const InputDecoration(labelText: 'Username')),
             TextField(controller: passwordController, decoration: const InputDecoration(labelText: 'Password'), obscureText: true),
             ElevatedButton(onPressed: login, child: const Text('Sign In')),
+            TextButton(
+              onPressed: () => launchUrl(_registerUrl),
+              child:const Text('Need an account? Register'),
+            ),
+            TextButton(
+              onPressed: () => launchUrl(_passwordResetUrl),
+              child:const Text('Forgot Password? Reset Password'),
+            ),
           ],
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   flutter_dotenv: ^6.0.0
   mockito: ^5.5.1
   material_color_utilities: ">=0.11.1 <0.13.0"
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Changes made:
Login view:
Added two text buttons. One bringing you to the register page and another to the forgot password page on TMDB website.

pubspec.yaml:
Added url_launcher dependency for the addition.